### PR TITLE
Small fixes to 0.2.0 version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,6 @@ julia:
 
 matrix:
     allow_failures:
-        - julia: 1.0
         - julia: nightly
 
 after_success:

--- a/src/mortar2dad.jl
+++ b/src/mortar2dad.jl
@@ -71,12 +71,8 @@ function project_from_master_to_slave_ad(slave_element::Element{E}, x1_, n1_, x2
         end
     end
 
-    info("x1 = $x1")
-    info("n1 = $n1")
-    info("x2 = $x2")
-    info("xi1 = $xi1, dxi1 = $dxi1")
-    info("-R(xi1) = $(-R(xi1))")
-    info("dR(xi1) = $(dR(xi1))")
+    @error("Projection from master to slave failed with the following data:",
+          x1, n1, x2, xi1, dxi1, -R(xi1), dR(xi1))
     error("find projection from master to slave: did not converge")
 
 end

--- a/test/test_01.jl
+++ b/test/test_01.jl
@@ -1,7 +1,7 @@
 # This file is a part of JuliaFEM.
 # License is MIT: see https://github.com/JuliaFEM/MortarContact2DAD.jl/blob/master/LICENSE
 
-using MortarContact2DAD, Test
+using FEMBase, MortarContact2DAD, Test
 using MortarContact2DAD: get_slave_dofs, get_master_dofs
 using MortarContact2DAD: project_from_master_to_slave_ad, project_from_slave_to_master_ad
 


### PR DESCRIPTION
* Fix one deprecated syntax `info`
* Do not allow to fail on Julia v1.0.0